### PR TITLE
Add publishing to OpenVSX

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -73,6 +73,9 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSC_MARKETPLACE_PAT }}
 
+      - name: Publish extension to OpenVSX
+        run: yarn publish-ovsx json-to-go-*.vsix -p ${{ secrets.OVSX_TOKEN }}
+
       - name: Extract release notes
         run: sed -n -e "/## \[$EXTENSION_VERSION\]/,/## \[[0-9]*\.[0-9]*\.[0-9]*\]/p" CHANGELOG.md | sed -e "/## \[$EXTENSION_VERSION\]/d" | perl -pe 'BEGIN{undef $/;} s/\n## \[[0-9]*\.[0-9]*\.[0-9]*\]\n/\n/sg' > RELEASE_NOTES.md
 

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "test": "jest",
     "build": "vsce package",
     "publish-marketplace": "vsce publish",
+    "publish-ovsx": "ovsx publish",
     "prepare": "husky"
   },
   "devDependencies": {
@@ -149,6 +150,7 @@
     "glob": "^7.1.6",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
+    "ovsx": "^0.10.8",
     "prettier": "^3.1.0",
     "prettier-eslint": "^16.1.2",
     "typescript": "^4.1.3"


### PR DESCRIPTION
Hey @mp3cko, I took a shot at implementing a step to publish to OpenVSX.
You still need to follow step 1-4 from [this](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions) and add the access token as a secret under the name `OVSX_TOKEN`

related to #10 